### PR TITLE
Update AWS base networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_eip.f5-xc-spoke-nat](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/eip) | resource |
+| [aws_eip.f5-xc-spoke2-nat](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/eip) | resource |
 | [aws_internet_gateway.f5-xc-services-vpc-gw](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/internet_gateway) | resource |
 | [aws_internet_gateway.f5-xc-spoke-vpc-gw](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/internet_gateway) | resource |
 | [aws_internet_gateway.f5-xc-spoke2-vpc-gw](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.f5-xc-spoke-vpc-nat](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/nat_gateway) | resource |
+| [aws_nat_gateway.f5-xc-spoke2-vpc-nat](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/nat_gateway) | resource |
 | [aws_network_acl_rule.deny_tcp_53](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.deny_udp_53](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.tcp_53](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/network_acl_rule) | resource |
@@ -36,13 +40,19 @@ No modules.
 | [aws_network_acl_rule.udp_53-2](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/network_acl_rule) | resource |
 | [aws_route.internet-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route.spoke-internet-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
+| [aws_route.spoke-workload-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route.spoke2-internet-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
+| [aws_route.spoke2-workload-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route_table.f5-xc-services-vpc-external-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
 | [aws_route_table.f5-xc-spoke-vpc-external-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
+| [aws_route_table.f5-xc-spoke-vpc-workload-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
 | [aws_route_table.f5-xc-spoke2-vpc-external-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
+| [aws_route_table.f5-xc-spoke2-vpc-workload-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
 | [aws_route_table_association.f5-xc-external-association](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.f5-xc-spoke-external-association](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.f5-xc-spoke-workload-association](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.f5-xc-spoke2-external-association](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.f5-xc-spoke2-workload-association](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table_association) | resource |
 | [aws_security_group.f5-xc-spoke-vpc](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/security_group) | resource |
 | [aws_security_group.f5-xc-spoke2-vpc](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/security_group) | resource |
 | [aws_security_group.f5-xc-vpc](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/security_group) | resource |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No modules.
 |------|------|
 | [aws_eip.f5-xc-spoke-nat](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/eip) | resource |
 | [aws_eip.f5-xc-spoke2-nat](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/eip) | resource |
+| [aws_instance.jumphost](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/instance) | resource |
 | [aws_internet_gateway.f5-xc-services-vpc-gw](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/internet_gateway) | resource |
 | [aws_internet_gateway.f5-xc-spoke-vpc-gw](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/internet_gateway) | resource |
 | [aws_internet_gateway.f5-xc-spoke2-vpc-gw](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/internet_gateway) | resource |
@@ -38,11 +39,17 @@ No modules.
 | [aws_network_acl_rule.tcp_53-2](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.udp_53](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.udp_53-2](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/network_acl_rule) | resource |
+| [aws_route.hub-to-spoke1](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
+| [aws_route.hub-to-spoke2](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route.internet-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route.spoke-internet-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route.spoke-workload-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
+| [aws_route.spoke1-external-to-hub](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
+| [aws_route.spoke1-workload-to-hub](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
+| [aws_route.spoke2-external-to-hub](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route.spoke2-internet-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route.spoke2-workload-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
+| [aws_route.spoke2-workload-to-hub](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route) | resource |
 | [aws_route_table.f5-xc-services-vpc-external-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
 | [aws_route_table.f5-xc-spoke-vpc-external-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
 | [aws_route_table.f5-xc-spoke-vpc-workload-rt](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/route_table) | resource |
@@ -68,21 +75,28 @@ No modules.
 | [aws_vpc.f5-xc-services](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/vpc) | resource |
 | [aws_vpc.f5-xc-spoke](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/vpc) | resource |
 | [aws_vpc.f5-xc-spoke2](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/vpc) | resource |
+| [aws_vpc_peering_connection.hubSpoke1](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/vpc_peering_connection) | resource |
+| [aws_vpc_peering_connection.hubSpoke2](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/resources/vpc_peering_connection) | resource |
+| [aws_ami.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/4.54.0/docs/data-sources/ami) | data source |
 | [http_http.myip](https://registry.terraform.io/providers/hashicorp/http/3.2.1/docs/data-sources/http) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_ami_search_name"></a> [ami\_search\_name](#input\_ami\_search\_name) | AWS AMI search filter to find correct image (Ubuntu) for region | `string` | `"ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230112"` | no |
 | <a name="input_auto_trust_localip"></a> [auto\_trust\_localip](#input\_auto\_trust\_localip) | if true, query ifconfig.io for public ip of terraform host. | `bool` | `false` | no |
 | <a name="input_awsRegion"></a> [awsRegion](#input\_awsRegion) | aws region | `string` | n/a | yes |
+| <a name="input_createJumphost"></a> [createJumphost](#input\_createJumphost) | Create a jumphost for troubleshooting purposes (true or false) | `bool` | n/a | yes |
 | <a name="input_projectPrefix"></a> [projectPrefix](#input\_projectPrefix) | projectPrefix name for tagging | `string` | n/a | yes |
+| <a name="input_resourceOwner"></a> [resourceOwner](#input\_resourceOwner) | Owner of the deployment for tagging purposes | `string` | n/a | yes |
 | <a name="input_servicesVpc"></a> [servicesVpc](#input\_servicesVpc) | Services VPC | `map(any)` | n/a | yes |
 | <a name="input_servicesVpcCidrBlock"></a> [servicesVpcCidrBlock](#input\_servicesVpcCidrBlock) | n/a | `string` | n/a | yes |
 | <a name="input_spoke2Vpc"></a> [spoke2Vpc](#input\_spoke2Vpc) | Spoke VPC | `map(any)` | n/a | yes |
 | <a name="input_spoke2VpcCidrBlock"></a> [spoke2VpcCidrBlock](#input\_spoke2VpcCidrBlock) | n/a | `string` | n/a | yes |
 | <a name="input_spokeVpc"></a> [spokeVpc](#input\_spokeVpc) | Spoke VPC | `map(any)` | n/a | yes |
 | <a name="input_spokeVpcCidrBlock"></a> [spokeVpcCidrBlock](#input\_spokeVpcCidrBlock) | n/a | `string` | n/a | yes |
+| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | SSH public key used to create an EC2 keypair | `string` | n/a | yes |
 | <a name="input_trusted_ip"></a> [trusted\_ip](#input\_trusted\_ip) | IP to allow external access | `string` | n/a | yes |
 
 ## Outputs
@@ -95,6 +109,7 @@ No modules.
 | <a name="output_awsRegion"></a> [awsRegion](#output\_awsRegion) | n/a |
 | <a name="output_externalSubnets"></a> [externalSubnets](#output\_externalSubnets) | n/a |
 | <a name="output_internalSubnets"></a> [internalSubnets](#output\_internalSubnets) | n/a |
+| <a name="output_jumphostSpoke1_public_ip"></a> [jumphostSpoke1\_public\_ip](#output\_jumphostSpoke1\_public\_ip) | Public IP address of jumphost in spoke 1 |
 | <a name="output_projectPrefix"></a> [projectPrefix](#output\_projectPrefix) | n/a |
 | <a name="output_securityGroup"></a> [securityGroup](#output\_securityGroup) | n/a |
 | <a name="output_serviceCidrBlock"></a> [serviceCidrBlock](#output\_serviceCidrBlock) | n/a |

--- a/dependency.tf
+++ b/dependency.tf
@@ -62,3 +62,8 @@ output serviceExternalRouteTable {
 output serviceCidrBlock {
   value = var.servicesVpcCidrBlock
 }
+
+output "jumphostSpoke1_public_ip" {
+  value       = var.createJumphost == true ? aws_instance.jumphost[0].public_ip : null
+  description = "Public IP address of jumphost in spoke 1"
+}

--- a/spoke.tf
+++ b/spoke.tf
@@ -155,7 +155,6 @@ resource "aws_security_group" "f5-xc-spoke-vpc" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-
   ingress {
     from_port   = 0
     to_port     = 0

--- a/spoke.tf
+++ b/spoke.tf
@@ -31,7 +31,7 @@ resource "aws_subnet" "f5-xc-spoke-internal" {
   availability_zone       = var.spokeVpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-external-${each.key}"
+    Name = "${var.projectPrefix}-f5-xc-spoke-internal-${each.key}"
   }
 }
 

--- a/spoke.tf
+++ b/spoke.tf
@@ -7,7 +7,8 @@ resource "aws_vpc" "f5-xc-spoke" {
   #enable_classiclink   = "false"
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-vpc"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-vpc"
+    Owner = var.resourceOwner
   }
 }
 
@@ -19,7 +20,8 @@ resource "aws_subnet" "f5-xc-spoke-external" {
   availability_zone       = var.spokeVpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-external-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-external-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -31,7 +33,8 @@ resource "aws_subnet" "f5-xc-spoke-internal" {
   availability_zone       = var.spokeVpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-internal-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-internal-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -43,7 +46,8 @@ resource "aws_subnet" "f5-xc-spoke-workload" {
   availability_zone       = var.spokeVpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-workload-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-workload-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -51,7 +55,8 @@ resource "aws_internet_gateway" "f5-xc-spoke-vpc-gw" {
   vpc_id = aws_vpc.f5-xc-spoke.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-vpc-igw"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-vpc-igw"
+    Owner = var.resourceOwner
   }
 }
 
@@ -59,7 +64,8 @@ resource "aws_route_table" "f5-xc-spoke-vpc-external-rt" {
   vpc_id = aws_vpc.f5-xc-spoke.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-external-rt"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-external-rt"
+    Owner = var.resourceOwner
   }
 }
 
@@ -80,26 +86,28 @@ resource "aws_eip" "f5-xc-spoke-nat" {
   vpc = true
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-nat-eip"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-nat-eip"
+    Owner = var.resourceOwner
   }
 }
 
 resource "aws_nat_gateway" "f5-xc-spoke-vpc-nat" {
   allocation_id = aws_eip.f5-xc-spoke-nat.id
   subnet_id     = aws_subnet.f5-xc-spoke-external["az1"].id
+  depends_on    = [aws_internet_gateway.f5-xc-spoke-vpc-gw]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-nat"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-nat"
+    Owner = var.resourceOwner
   }
-
-  depends_on = [aws_internet_gateway.f5-xc-spoke-vpc-gw]
 }
 
 resource "aws_route_table" "f5-xc-spoke-vpc-workload-rt" {
   vpc_id = aws_vpc.f5-xc-spoke.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-workload-rt"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-workload-rt"
+    Owner = var.resourceOwner
   }
 }
 
@@ -170,6 +178,7 @@ resource "aws_security_group" "f5-xc-spoke-vpc" {
   }
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke-sg"
+    Name  = "${var.projectPrefix}-f5-xc-spoke-sg"
+    Owner = var.resourceOwner
   }
 }

--- a/spoke.tf
+++ b/spoke.tf
@@ -169,5 +169,8 @@ resource "aws_security_group" "f5-xc-spoke-vpc" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-}
 
+  tags = {
+    Name = "${var.projectPrefix}-f5-xc-spoke-sg"
+  }
+}

--- a/spoke.tf
+++ b/spoke.tf
@@ -86,7 +86,7 @@ resource "aws_eip" "f5-xc-spoke-nat" {
 
 resource "aws_nat_gateway" "f5-xc-spoke-vpc-nat" {
   allocation_id = aws_eip.f5-xc-spoke-nat.id
-  subnet_id     = aws_subnet.f5-xc-spoke-workload["az1"].id
+  subnet_id     = aws_subnet.f5-xc-spoke-external["az1"].id
 
   tags = {
     Name = "${var.projectPrefix}-f5-xc-spoke-nat"

--- a/spoke.tf
+++ b/spoke.tf
@@ -106,7 +106,7 @@ resource "aws_route_table" "f5-xc-spoke-vpc-workload-rt" {
 resource "aws_route" "spoke-workload-rt" {
   route_table_id         = aws_route_table.f5-xc-spoke-vpc-workload-rt.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_nat_gateway.f5-xc-spoke-vpc-nat.id
+  nat_gateway_id         = aws_nat_gateway.f5-xc-spoke-vpc-nat.id
   depends_on             = [aws_route_table.f5-xc-spoke-vpc-workload-rt]
 }
 

--- a/spoke2.tf
+++ b/spoke2.tf
@@ -86,7 +86,7 @@ resource "aws_eip" "f5-xc-spoke2-nat" {
 
 resource "aws_nat_gateway" "f5-xc-spoke2-vpc-nat" {
   allocation_id = aws_eip.f5-xc-spoke2-nat.id
-  subnet_id     = aws_subnet.f5-xc-spoke2-workload["az1"].id
+  subnet_id     = aws_subnet.f5-xc-spoke2-external["az1"].id
 
   tags = {
     Name = "${var.projectPrefix}-f5-xc-spoke2-nat"

--- a/spoke2.tf
+++ b/spoke2.tf
@@ -7,7 +7,8 @@ resource "aws_vpc" "f5-xc-spoke2" {
   #enable_classiclink   = "false"
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-vpc"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-vpc"
+    Owner = var.resourceOwner
   }
 }
 
@@ -19,7 +20,8 @@ resource "aws_subnet" "f5-xc-spoke2-external" {
   availability_zone       = var.spoke2Vpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-external-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-external-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -31,7 +33,8 @@ resource "aws_subnet" "f5-xc-spoke2-internal" {
   availability_zone       = var.spoke2Vpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-internal-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-internal-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -43,7 +46,8 @@ resource "aws_subnet" "f5-xc-spoke2-workload" {
   availability_zone       = var.spoke2Vpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-workload-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-workload-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -51,7 +55,8 @@ resource "aws_internet_gateway" "f5-xc-spoke2-vpc-gw" {
   vpc_id = aws_vpc.f5-xc-spoke2.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-vpc-igw"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-vpc-igw"
+    Owner = var.resourceOwner
   }
 }
 
@@ -59,7 +64,8 @@ resource "aws_route_table" "f5-xc-spoke2-vpc-external-rt" {
   vpc_id = aws_vpc.f5-xc-spoke2.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-external-rt"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-external-rt"
+    Owner = var.resourceOwner
   }
 }
 
@@ -80,26 +86,28 @@ resource "aws_eip" "f5-xc-spoke2-nat" {
   vpc = true
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-nat-eip"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-nat-eip"
+    Owner = var.resourceOwner
   }
 }
 
 resource "aws_nat_gateway" "f5-xc-spoke2-vpc-nat" {
   allocation_id = aws_eip.f5-xc-spoke2-nat.id
   subnet_id     = aws_subnet.f5-xc-spoke2-external["az1"].id
+  depends_on    = [aws_internet_gateway.f5-xc-spoke2-vpc-gw]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-nat"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-nat"
+    Owner = var.resourceOwner
   }
-
-  depends_on = [aws_internet_gateway.f5-xc-spoke2-vpc-gw]
 }
 
 resource "aws_route_table" "f5-xc-spoke2-vpc-workload-rt" {
   vpc_id = aws_vpc.f5-xc-spoke2.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-workload-rt"
+    Name  = "${var.projectPrefix}-f5-xc-spoke2-workload-rt"
+    Owner = var.resourceOwner
   }
 }
 
@@ -171,5 +179,6 @@ resource "aws_security_group" "f5-xc-spoke2-vpc" {
 
   tags = {
     Name = "${var.projectPrefix}-f5-xc-spoke2-sg"
+    Owner = var.resourceOwner
   }
 }

--- a/spoke2.tf
+++ b/spoke2.tf
@@ -106,7 +106,7 @@ resource "aws_route_table" "f5-xc-spoke2-vpc-workload-rt" {
 resource "aws_route" "spoke2-workload-rt" {
   route_table_id         = aws_route_table.f5-xc-spoke2-vpc-workload-rt.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_nat_gateway.f5-xc-spoke2-vpc-nat.id
+  nat_gateway_id         = aws_nat_gateway.f5-xc-spoke2-vpc-nat.id
   depends_on             = [aws_route_table.f5-xc-spoke2-vpc-workload-rt]
 }
 

--- a/spoke2.tf
+++ b/spoke2.tf
@@ -31,7 +31,7 @@ resource "aws_subnet" "f5-xc-spoke2-internal" {
   availability_zone       = var.spoke2Vpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-spoke2-external-${each.key}"
+    Name = "${var.projectPrefix}-f5-xc-spoke2-internal-${each.key}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,10 @@ variable "projectPrefix" {
   type        = string
   description = "projectPrefix name for tagging"
 }
+variable "resourceOwner" {
+  type        = string
+  description = "Owner of the deployment for tagging purposes"
+}
 
 variable "trusted_ip" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,17 @@ variable "spoke2Vpc" {
   description = "Spoke VPC"
   type        = map(any)
 }
+
+variable "createJumphost" {
+  description = "Create a jumphost for troubleshooting purposes (true or false)"
+  type        = bool
+}
+variable "ami_search_name" {
+  type        = string
+  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230112"
+  description = "AWS AMI search filter to find correct image (Ubuntu) for region"
+}
+variable "ssh_key" {
+  description = "SSH public key used to create an EC2 keypair"
+  type        = string
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -7,7 +7,8 @@ resource "aws_vpc" "f5-xc-services" {
   #enable_classiclink   = "false"
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-services-vpc"
+    Name  = "${var.projectPrefix}-f5-xc-services-vpc"
+    Owner = var.resourceOwner
   }
 }
 
@@ -22,7 +23,8 @@ resource "aws_subnet" "f5-xc-services-external" {
   availability_zone       = var.servicesVpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-services-external-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-services-external-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -34,7 +36,8 @@ resource "aws_subnet" "f5-xc-services-internal" {
   availability_zone       = var.servicesVpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-services-internal-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-services-internal-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -46,7 +49,8 @@ resource "aws_subnet" "f5-xc-services-workload" {
   availability_zone       = var.servicesVpc.azs[each.key]["az"]
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-services-workload-${each.key}"
+    Name  = "${var.projectPrefix}-f5-xc-services-workload-${each.key}"
+    Owner = var.resourceOwner
   }
 }
 
@@ -55,7 +59,8 @@ resource "aws_internet_gateway" "f5-xc-services-vpc-gw" {
   vpc_id = aws_vpc.f5-xc-services.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-services-vpc-igw"
+    Name  = "${var.projectPrefix}-f5-xc-services-vpc-igw"
+    Owner = var.resourceOwner
   }
 }
 
@@ -63,7 +68,8 @@ resource "aws_route_table" "f5-xc-services-vpc-external-rt" {
   vpc_id = aws_vpc.f5-xc-services.id
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-services-external-rt"
+    Name  = "${var.projectPrefix}-f5-xc-services-external-rt"
+    Owner = var.resourceOwner
   }
 }
 
@@ -121,7 +127,8 @@ resource "aws_security_group" "f5-xc-vpc" {
   }
 
   tags = {
-    Name = "${var.projectPrefix}-f5-xc-sg"
+    Name  = "${var.projectPrefix}-f5-xc-sg"
+    Owner = var.resourceOwner
   }
 }
 

--- a/vpc.tf
+++ b/vpc.tf
@@ -119,6 +119,10 @@ resource "aws_security_group" "f5-xc-vpc" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  tags = {
+    Name = "${var.projectPrefix}-f5-xc-sg"
+  }
 }
 
 resource "aws_network_acl_rule" "tcp_53" {

--- a/vpcPeering.tf
+++ b/vpcPeering.tf
@@ -24,22 +24,18 @@ resource "aws_vpc_peering_connection" "hubSpoke2" {
 
 ############################ Routes ############################
 
-resource "aws_default_route_table" "f5-xc-services-default-rt" {
-  default_route_table_id = aws_vpc.f5-xc-services.default_route_table_id
+resource "aws_route" "hub-to-spoke1" {
+  route_table_id            = aws_route_table.f5-xc-services-vpc-external-rt.id
+  destination_cidr_block    = var.spokeVpcCidrBlock
+  vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke1.id
+  depends_on                = [aws_route_table.f5-xc-services-vpc-external-rt]
+}
 
-  route {
-    cidr_block                = var.spokeVpcCidrBlock
-    vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke1.id
-  }
-  route {
-    cidr_block                = var.spoke2VpcCidrBlock
-    vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke2.id
-  }
-
-  tags = {
-    Name  = "${var.projectPrefix}-f5-xc-services-default-rt"
-    Owner = var.resourceOwner
-  }
+resource "aws_route" "hub-to-spoke2" {
+  route_table_id            = aws_route_table.f5-xc-services-vpc-external-rt.id
+  destination_cidr_block    = var.spoke2VpcCidrBlock
+  vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke2.id
+  depends_on                = [aws_route_table.f5-xc-services-vpc-external-rt]
 }
 
 resource "aws_route" "spoke1-external-to-hub" {

--- a/vpcPeering.tf
+++ b/vpcPeering.tf
@@ -1,0 +1,71 @@
+############################ VPC Peering ############################
+
+resource "aws_vpc_peering_connection" "hubSpoke1" {
+  peer_vpc_id = aws_vpc.f5-xc-spoke.id
+  vpc_id      = aws_vpc.f5-xc-services.id
+  auto_accept = true
+
+  tags = {
+    Name  = "${var.projectPrefix}-hub-to-spoke1"
+    Owner = var.resourceOwner
+  }
+}
+
+resource "aws_vpc_peering_connection" "hubSpoke2" {
+  peer_vpc_id = aws_vpc.f5-xc-spoke2.id
+  vpc_id      = aws_vpc.f5-xc-services.id
+  auto_accept = true
+
+  tags = {
+    Name  = "${var.projectPrefix}-hub-to-spoke2"
+    Owner = var.resourceOwner
+  }
+}
+
+############################ Routes ############################
+
+resource "aws_default_route_table" "f5-xc-services-default-rt" {
+  default_route_table_id = aws_vpc.f5-xc-services.default_route_table_id
+
+  route {
+    cidr_block                = var.spokeVpcCidrBlock
+    vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke1.id
+  }
+  route {
+    cidr_block                = var.spoke2VpcCidrBlock
+    vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke2.id
+  }
+
+  tags = {
+    Name  = "${var.projectPrefix}-f5-xc-services-default-rt"
+    Owner = var.resourceOwner
+  }
+}
+
+resource "aws_route" "spoke1-external-to-hub" {
+  route_table_id            = aws_route_table.f5-xc-spoke-vpc-external-rt.id
+  destination_cidr_block    = var.servicesVpcCidrBlock
+  vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke1.id
+  depends_on                = [aws_route_table.f5-xc-spoke-vpc-external-rt]
+}
+
+resource "aws_route" "spoke1-workload-to-hub" {
+  route_table_id            = aws_route_table.f5-xc-spoke-vpc-workload-rt.id
+  destination_cidr_block    = var.servicesVpcCidrBlock
+  vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke1.id
+  depends_on                = [aws_route_table.f5-xc-spoke-vpc-workload-rt]
+}
+
+resource "aws_route" "spoke2-external-to-hub" {
+  route_table_id            = aws_route_table.f5-xc-spoke2-vpc-external-rt.id
+  destination_cidr_block    = var.servicesVpcCidrBlock
+  vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke2.id
+  depends_on                = [aws_route_table.f5-xc-spoke2-vpc-external-rt]
+}
+
+resource "aws_route" "spoke2-workload-to-hub" {
+  route_table_id            = aws_route_table.f5-xc-spoke2-vpc-workload-rt.id
+  destination_cidr_block    = var.servicesVpcCidrBlock
+  vpc_peering_connection_id = aws_vpc_peering_connection.hubSpoke2.id
+  depends_on                = [aws_route_table.f5-xc-spoke2-vpc-workload-rt]
+}


### PR DESCRIPTION
The base network setup requires connectivity between hub and spoke.

- add vpc peering
- add routes
- add jumphost for troubleshooting optional flag (default = false)
- add NAT gateway for backend app servers to reach internet and onboard